### PR TITLE
Fix envio pricing handling

### DIFF
--- a/src/main/java/co/edu/uniquindio/poo/plataformalogistica/model/Envio.java
+++ b/src/main/java/co/edu/uniquindio/poo/plataformalogistica/model/Envio.java
@@ -16,7 +16,7 @@ public abstract class Envio {
     protected double pesoKg;
     protected double volumenM3;
     protected boolean prioridad;
-    protected Tarifa tarifa;
+    protected double precio;
     protected String ID;
     protected EstadoEnvio estadoEnvio;
     protected Paquete paquete;
@@ -27,7 +27,7 @@ public abstract class Envio {
                  LocalDate fechaCreacion, LocalDate fechaEntrega,
                  Direccion origen, Direccion destino,
                  double distanciaKm, double pesoKg, double volumenM3,
-                 boolean prioridad, Tarifa tarifa, String ID,
+                 boolean prioridad, double precio, String ID,
                  EstadoEnvio estadoEnvio, Paquete paquete,
                  List<ServicioAdicional> serviciosAdicionales) {
 
@@ -42,7 +42,7 @@ public abstract class Envio {
         this.pesoKg = pesoKg;
         this.volumenM3 = volumenM3;
         this.prioridad = prioridad;
-        this.tarifa = tarifa;
+        this.precio = precio;
         this.ID =ID;
         this.estadoEnvio = estadoEnvio;
         this.paquete = paquete;
@@ -86,12 +86,12 @@ public abstract class Envio {
         return fechaEntrega;
     }
 
-    public Tarifa getTarifa() {
-        return tarifa;
+    public double getPrecio() {
+        return precio;
     }
 
-    public void setTarifa(Tarifa tarifa) {
-        this.tarifa = tarifa;
+    public void setPrecio(double precio) {
+        this.precio = precio;
     }
 
     public String getID() {
@@ -148,12 +148,14 @@ public abstract class Envio {
 
     public List<ServicioAdicional> getServiciosAdicionales() {
         return new ArrayList<>(serviciosAdicionales);
+    }
 
-        public void agregarServicioAdicional(ServicioAdicional servicio) {
-            if (servicio == null) return;
-            if (!serviciosAdicionales.contains(servicio)) {
-                serviciosAdicionales.add(servicio);
-            }
+    public void agregarServicioAdicional(ServicioAdicional servicio) {
+        if (servicio == null) return;
+        if (!serviciosAdicionales.contains(servicio)) {
+            serviciosAdicionales.add(servicio);
+        }
+    }
 
     public LocalDate getFechaCreacion() {
         return fechaCreacion;
@@ -174,7 +176,7 @@ public abstract class Envio {
                 ", fechaCreacion=" + fechaCreacion +
                 ", fechaEntrega=" + fechaEntrega +
                 ", destino='" + (destino != null ? destino.toString() : "") + '\'' +
-                ", precio=" + tarifa +
+                ", precio=" + precio +
                 ", ID='" + ID + '\'' +
                 ", estadoEnvio='" + estadoEnvio + '\'' +
                 ", paquete=" + paquete +

--- a/src/main/java/co/edu/uniquindio/poo/plataformalogistica/model/EnvioUrbano.java
+++ b/src/main/java/co/edu/uniquindio/poo/plataformalogistica/model/EnvioUrbano.java
@@ -25,7 +25,7 @@ public class EnvioUrbano extends Envio {
         System.out.println("Repartidor: " + repartidor.getNombre());
         System.out.println("Origen: " + (origen != null ? origen : ""));
         System.out.println("Destino: " + (destino != null ? destino : ""));
-        System.out.println("Precio: $" + tarifa);
+        System.out.println("Precio: $" + precio);
         System.out.println("Estado: " + estadoEnvio);
         System.out.println("Paquete: " + paquete.getNombre() + " (" + paquete.getPeso() + " kg)");
         System.out.println("Fecha de Creación: " + fechaCreacion);

--- a/src/main/java/co/edu/uniquindio/poo/plataformalogistica/model/PlataformaLogistica.java
+++ b/src/main/java/co/edu/uniquindio/poo/plataformalogistica/model/PlataformaLogistica.java
@@ -328,7 +328,7 @@ public class PlataformaLogistica {
             if (fecha != null &&
                     (fecha.isEqual(desde) || fecha.isAfter(desde)) &&
                     (fecha.isEqual(hasta) || fecha.isBefore(hasta))) {
-                totalIngresos += envio.getTarifa();
+                totalIngresos += envio.getPrecio();
             }
         }
 


### PR DESCRIPTION
## Summary
- store the calculated price directly on `Envio`, exposing a `getPrecio` accessor that callers such as `PlataformaLogistica` and `UsuarioController` can use
- fix the `EnvioUrbano` details output and the `Envio` helper for servicios adicionales so that pricing and service state are handled consistently
- ensure revenue calculations now sum the stored price instead of the tariff object

## Testing
- `mvn test` *(fails: Maven could not download plugins from Maven Central – HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4c9830848323af44ff689a3a4756)